### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ['1.25']
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Install just
+        uses: extractions/setup-just@v3
+
+      - name: Verify dependencies
+        run: go mod verify
+
+      - name: Check formatting
+        run: just fmt-check
+
+      - name: Run tests with coverage
+        run: just coverage-report
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Install just
+        uses: extractions/setup-just@v3
+
+      - name: Build
+        run: just build
+
+      - name: Verify binary runs
+        run: |
+          echo '{"tool_name": "Bash", "tool_input": {"command": "ls"}}' | ./mmi

--- a/justfile
+++ b/justfile
@@ -10,9 +10,14 @@ build:
 test:
     go test -v
 
-# Run tests with coverage
+# Run tests with coverage summary
 coverage:
     go test -cover
+
+# Run tests with coverage report file
+coverage-report:
+    go test -v -coverprofile=coverage.out ./...
+    go tool cover -func=coverage.out
 
 # Run tests with verbose output and coverage
 test-coverage:
@@ -22,6 +27,10 @@ test-coverage:
 fmt:
     go fmt ./...
 
+# Check formatting without modifying files
+fmt-check:
+    @test -z "$(gofmt -l .)" || (echo "Code is not formatted. Run 'just fmt'" && gofmt -d . && exit 1)
+
 # Run Go vet linter
 vet:
     go vet ./...
@@ -29,10 +38,13 @@ vet:
 # Clean build artifacts
 clean:
     go clean
-    rm -f mmi
+    rm -f mmi coverage.out
 
-# Run all checks (fmt, vet, test)
-check: fmt vet test
+# Run all checks (fmt-check, vet, test)
+check: fmt-check vet test
+
+# Run CI checks locally (matches GitHub Actions)
+ci: fmt-check coverage-report build
 
 # Build and install (default: /usr/local/bin)
 install prefix="/usr/local": build

--- a/main.go
+++ b/main.go
@@ -1,7 +1,8 @@
 // mmi (mother may I?) - Claude Code PreToolUse Hook for Bash Command Approval
 //
 // This hook auto-approves Bash commands that are safe combinations of:
-//   WRAPPERS (timeout, env vars, .venv/bin/) + CORE COMMANDS (git, pytest, etc.)
+//
+//	WRAPPERS (timeout, env vars, .venv/bin/) + CORE COMMANDS (git, pytest, etc.)
 //
 // Usage in ~/.claude/settings.json:
 //


### PR DESCRIPTION
## Summary
- Set up continuous integration with tests on Go 1.25
- Add format checking and coverage reporting
- Add build verification

## Justfile commands for local CI parity
- `fmt-check`: Check formatting without modifying files
- `coverage-report`: Run tests with coverage file output
- `ci`: Run all CI checks locally

## Test plan
- [ ] Verify CI workflow runs successfully on push/PR
- [ ] Test `just ci` locally matches GitHub Actions behavior
