### PR TITLE
Simplify variable declarations and remove intermediate assignment

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -31,8 +31,8 @@ func BenchmarkSplitCommandChain(b *testing.B) {
 
 // BenchmarkProcess benchmarks the full command approval process
 func BenchmarkProcess(b *testing.B) {
-	cfg := config.Get()
-	_ = cfg // ensure config is loaded before benchmark
+	// Ensure config is loaded before benchmark
+	_ = config.Get()
 
 	benchmarks := []struct {
 		name  string

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -11,9 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	initForce bool
-)
+var initForce bool
 
 var initCmd = &cobra.Command{
 	Use:   "init",


### PR DESCRIPTION
## Summary
- Simplify single-variable `var` block to simple declaration in `cmd/init.go`
- Remove unnecessary intermediate variable assignment in `benchmark_test.go`

## Test plan
- [x] All existing tests pass
- [x] No functional changes, only code style improvements