### PR TITLE
Output explicit permission decision for non-approved commands

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -158,12 +158,12 @@ func TestRootCmdFlags(t *testing.T) {
 	cmd.PersistentFlags().BoolVar(&noAuditLog, "no-audit-log", false, "Disable audit logging")
 
 	tests := []struct {
-		name            string
-		args            []string
-		expectVerbose   bool
-		expectDryRun    bool
-		expectProfile   string
-		expectNoAudit   bool
+		name          string
+		args          []string
+		expectVerbose bool
+		expectDryRun  bool
+		expectProfile string
+		expectNoAudit bool
 	}{
 		{
 			name:          "no flags",

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -28,9 +28,14 @@ func runHook(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	// Normal mode: output JSON approval to stdout
+	// Normal mode: output JSON decision to stdout
 	if result.Approved {
 		fmt.Print(hook.FormatApproval(result.Reason))
+	} else {
+		reason := "command not in allow list"
+		if result.Reason != "" {
+			reason = result.Reason
+		}
+		fmt.Print(hook.FormatAsk(reason))
 	}
-	// Silent rejection (no output) for non-approved commands
 }

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -246,9 +246,12 @@ func TestRunHookNormalModeRejectedSilent(t *testing.T) {
 	io.Copy(&buf, stdoutR)
 	output := buf.String()
 
-	// Rejected commands produce no output in normal mode
-	if output != "" {
-		t.Errorf("expected no output for rejected command, got: %s", output)
+	// Rejected commands produce ask JSON output
+	if output == "" {
+		t.Errorf("expected ask output for rejected command, got nothing")
+	}
+	if !strings.Contains(output, `"permissionDecision":"ask"`) {
+		t.Errorf("expected ask permission decision, got: %s", output)
 	}
 }
 

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -261,6 +261,19 @@ func FormatApproval(reason string) string {
 	return string(data) + "\n"
 }
 
+// FormatAsk returns the JSON ask output with a trailing newline
+func FormatAsk(reason string) string {
+	output := Output{
+		HookSpecificOutput: SpecificOutput{
+			HookEventName:            "PreToolUse",
+			PermissionDecision:       "ask",
+			PermissionDecisionReason: reason,
+		},
+	}
+	data, _ := json.Marshal(output)
+	return string(data) + "\n"
+}
+
 // SplitCommandChain splits command into segments on &&, ||, ;, |, & using a proper shell parser.
 // This handles quoted strings, redirections, and other shell syntax correctly.
 func SplitCommandChain(cmd string) []string {

--- a/main_test.go
+++ b/main_test.go
@@ -367,29 +367,50 @@ func TestIntegration(t *testing.T) {
 		}
 	})
 
-	t.Run("unsafe command produces no output", func(t *testing.T) {
+	t.Run("unsafe command produces ask output", func(t *testing.T) {
 		input := `{"tool_name":"Bash","tool_input":{"command":"rm -rf /"}}`
 		output, _ := runMmi(t, input)
 
-		if output != "" {
-			t.Errorf("Expected no output, got %q", output)
+		if output == "" {
+			t.Errorf("Expected ask output, got nothing")
+		}
+		var result hook.Output
+		if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &result); err != nil {
+			t.Fatalf("Failed to parse output: %v", err)
+		}
+		if result.HookSpecificOutput.PermissionDecision != "ask" {
+			t.Errorf("Expected 'ask', got %q", result.HookSpecificOutput.PermissionDecision)
 		}
 	})
 
-	t.Run("non-Bash tool produces no output", func(t *testing.T) {
+	t.Run("non-Bash tool produces ask output", func(t *testing.T) {
 		input := `{"tool_name":"Read","tool_input":{"file":"/etc/passwd"}}`
 		output, _ := runMmi(t, input)
 
-		if output != "" {
-			t.Errorf("Expected no output, got %q", output)
+		if output == "" {
+			t.Errorf("Expected ask output, got nothing")
+		}
+		var result hook.Output
+		if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &result); err != nil {
+			t.Fatalf("Failed to parse output: %v", err)
+		}
+		if result.HookSpecificOutput.PermissionDecision != "ask" {
+			t.Errorf("Expected 'ask', got %q", result.HookSpecificOutput.PermissionDecision)
 		}
 	})
 
-	t.Run("invalid JSON produces no output", func(t *testing.T) {
+	t.Run("invalid JSON produces ask output", func(t *testing.T) {
 		output, exitCode := runMmi(t, "invalid json")
 
-		if output != "" {
-			t.Errorf("Expected no output, got %q", output)
+		if output == "" {
+			t.Errorf("Expected ask output, got nothing")
+		}
+		var result hook.Output
+		if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &result); err != nil {
+			t.Fatalf("Failed to parse output: %v", err)
+		}
+		if result.HookSpecificOutput.PermissionDecision != "ask" {
+			t.Errorf("Expected 'ask', got %q", result.HookSpecificOutput.PermissionDecision)
 		}
 		if exitCode != 0 {
 			t.Errorf("Expected exit 0, got %d", exitCode)
@@ -563,7 +584,7 @@ func TestInitConfig(t *testing.T) {
 		t.Error("Init() should return error when config file doesn't exist")
 	}
 
-	// Config should be empty (deny all) when no config file exists
+	// Config should be empty (ask all) when no config file exists
 	cfg := config.Get()
 	if len(cfg.WrapperPatterns) != 0 {
 		t.Error("WrapperPatterns should be empty when no config file exists")


### PR DESCRIPTION
## Summary
- Add `FormatAsk()` function to output explicit JSON response for non-approved commands
- Change from silent rejection to outputting `permissionDecision: "ask"` which prompts user confirmation
- Fixes issue where Claude Code's allow rules in settings.json would override hook decisions

## Test plan
- [x] All existing tests updated and passing
- [x] Verify mmi outputs `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask",...}}` for rejected commands