### PR TITLE
Reject unparseable bash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ subcommands = ["diff", "log", "status", "add"]
 flags = ["-C <arg>"]
 
 [[commands.regex]]
-pattern = '^for\s+\w+\s+in\s'
-name = "for loop"
+pattern = '^(true|false|exit(\s+\d+)?)$'
+name = "shell builtin"
 ```
 
 ### Config Includes
@@ -229,7 +229,6 @@ The default configuration is intentionally restrictive. Use example configs for 
 | **Unix Utilities** | `ls`, `cat`, `head`, `tail`, `wc`, `find`, `grep`, `rg`, `file`, `which`, `pwd`, `du`, `df`, `curl`, `sort`, `uniq`, `cut`, `tr`, `awk`, `sed`, `xargs` |
 | **File Ops** | `touch`, `make` |
 | **Shell** | `echo`, `cd`, `true`, `false`, `exit`, `sleep` |
-| **Loops** | `for`, `while` |
 
 ### Additional Commands (via Example Configs)
 
@@ -260,9 +259,11 @@ Disable with `--no-audit-log`.
 
 - Deny patterns are checked first and override all approvals
 - Unrecognized commands are automatically rejected
+- Unparseable commands (incomplete syntax, unclosed quotes) are rejected
 - Command substitution (`$(...)` and backticks) is always rejected
 - Command chains are only approved if ALL segments are safe
 - Only explicitly allowlisted patterns are allowed
+- Shell loops (`while`, `for`) must be complete; their inner commands are extracted and validated individually
 
 ## Example Configurations
 

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -23,7 +23,7 @@ func BenchmarkSplitCommandChain(b *testing.B) {
 	for _, bm := range benchmarks {
 		b.Run(bm.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_ = hook.SplitCommandChain(bm.cmd)
+				_, _ = hook.SplitCommandChain(bm.cmd)
 			}
 		})
 	}

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -33,7 +33,7 @@ func FuzzSplitCommandChain(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, cmd string) {
 		// Just ensure no panics
-		_ = hook.SplitCommandChain(cmd)
+		_, _ = hook.SplitCommandChain(cmd)
 	})
 }
 

--- a/internal/config/config.toml
+++ b/internal/config/config.toml
@@ -94,11 +94,3 @@ name = "shell builtin"
 [[commands.regex]]
 pattern = "^[A-Z_][A-Z0-9_]*=\S*$"
 name = "var assignment"
-
-[[commands.regex]]
-pattern = "^for\s+\w+\s+in\s"
-name = "for loop"
-
-[[commands.regex]]
-pattern = "^while\s"
-name = "while loop"


### PR DESCRIPTION
## Summary

- Reject unparseable bash commands instead of silently falling back to treating them as single segments
- Remove unnecessary `while`/`for` regex patterns from config (complete loops are parsed by the shell AST and their inner commands extracted)
- `SplitCommandChain` now returns an error when parsing fails

## Test plan

- [x] Run `go test ./...` - all tests pass
- [x] Test complete while loop: `while true; do echo hi; done` → approved (extracts `true` and `echo hi`)
- [x] Test incomplete while loop: `while true` → rejected as unparseable
- [x] Test unclosed quotes: `echo 'hello` → rejected as unparseable