### PR TITLE
Remove support for multiple profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`mmi completion`**: Shell completion scripts for bash, zsh, fish, and PowerShell
 - **`--dry-run` flag**: Test command approval without JSON output
 - **`--verbose` / `-v` flag**: Enable debug logging
-- **`--profile` flag**: Select configuration profile
 - **`--no-audit-log` flag**: Disable audit logging
 
 #### Configuration
@@ -24,8 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `[[deny.simple]]` for command names
   - `[[deny.regex]]` for custom patterns
 - **Config includes**: Split config across multiple files with `include = [...]`
-- **Config profiles**: Multiple named configs in `~/.config/mmi/profiles/`
-  - Select via `--profile` flag or `MMI_PROFILE` env var
 
 #### Logging & Debugging
 - **Structured logging**: Debug output using Go's `log/slog`

--- a/README.md
+++ b/README.md
@@ -116,22 +116,7 @@ Split your configuration across multiple files:
 include = ["python.toml", "rust.toml"]
 ```
 
-### Config Profiles
-
-Create named profiles in `~/.config/mmi/profiles/`:
-
-```bash
-~/.config/mmi/profiles/strict.toml
-~/.config/mmi/profiles/python.toml
-```
-
-Select a profile via flag or environment variable:
-
-```bash
-mmi --profile strict
-# or
-MMI_PROFILE=strict mmi
-```
+To use different configurations for different projects, set the `MMI_CONFIG` environment variable to point to a different config directory.
 
 ## CLI Commands
 
@@ -182,7 +167,6 @@ mmi completion powershell > mmi.ps1
 |------|-------------|
 | `-v, --verbose` | Enable debug logging |
 | `--dry-run` | Test command approval without JSON output |
-| `--profile NAME` | Use a specific config profile |
 | `--no-audit-log` | Disable audit logging |
 
 ## How It Works
@@ -316,7 +300,7 @@ Use `mmi validate` to see your compiled patterns, or use the `--dry-run` flag to
 
 ### Can I have different configurations for different projects?
 
-Yes, use profiles. Store configurations in `~/.config/mmi/profiles/<name>.toml` and activate with `--profile <name>` flag or `MMI_PROFILE` environment variable.
+Yes, use the `MMI_CONFIG` environment variable to point to a different config directory. For example, set `MMI_CONFIG=/path/to/project/.mmi` to use a project-specific configuration.
 
 ### How do wrappers work?
 
@@ -333,10 +317,6 @@ Common causes:
 - **Command substitution**: Commands containing `$(...)` or backticks are always rejected
 - **Command chains**: If using `&&`, `||`, `|`, or `;`, all segments must be approved
 - **Pattern mismatch**: Use `mmi validate` to verify your patterns and `--verbose` to see why rejection occurred
-
-### What's the difference between config includes and profiles?
-
-**Includes** merge patterns from multiple TOML files into a single configuration (e.g., `include = ["python.toml", "rust.toml"]`). **Profiles** are complete alternative configurations stored in `~/.config/mmi/profiles/` and selected via `--profile` or `MMI_PROFILE`. Use includes to compose rules; use profiles to switch between different setups entirely.
 
 ## Testing
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,8 +2,6 @@
 package cmd
 
 import (
-	"os"
-
 	"github.com/dgerlanc/mmi/internal/audit"
 	"github.com/dgerlanc/mmi/internal/config"
 	"github.com/dgerlanc/mmi/internal/logger"
@@ -14,7 +12,6 @@ var (
 	// Global flags
 	verbose    bool
 	dryRun     bool
-	profile    string
 	noAuditLog bool
 )
 
@@ -53,24 +50,13 @@ func init() {
 	// Global flags
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output (debug logging)")
 	rootCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "Test command approval without JSON output")
-	rootCmd.PersistentFlags().StringVar(&profile, "profile", "", "Config profile to use (or set MMI_PROFILE env var)")
 	rootCmd.PersistentFlags().BoolVar(&noAuditLog, "no-audit-log", false, "Disable audit logging")
 }
 
 // initApp initializes the application (logger, config, audit)
 func initApp() {
-	// Check for profile from env var if not set via flag
-	if profile == "" {
-		profile = os.Getenv("MMI_PROFILE")
-	}
-
 	// Initialize logger
 	logger.Init(logger.Options{Verbose: verbose})
-
-	// Set profile before initializing config
-	if profile != "" {
-		config.SetProfile(profile)
-	}
 
 	// Initialize config (uses embedded defaults if no config file exists)
 	config.Init()
@@ -87,9 +73,4 @@ func IsVerbose() bool {
 // IsDryRun returns whether dry-run mode is enabled
 func IsDryRun() bool {
 	return dryRun
-}
-
-// GetProfile returns the current profile name
-func GetProfile() string {
-	return profile
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -10,9 +10,6 @@ import (
 
 // runHook is the default command that processes stdin for command approval
 func runHook(cmd *cobra.Command, args []string) {
-	// Set profile for audit logging
-	hook.SetProfile(profile)
-
 	// Process the command
 	result := hook.ProcessWithResult(os.Stdin)
 

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -59,7 +59,7 @@
 
 17. ~~**Support config includes**~~ ✓ IMPLEMENTED - Config can be split into multiple files using includes.
 
-18. ~~**Add config profiles**~~ ✓ IMPLEMENTED - Multiple named profiles are supported and switchable via environment variable.
+18. ~~**Add config profiles**~~ ✗ REMOVED - Use `MMI_CONFIG` environment variable to point to different config directories instead.
 
 19. **Config schema validation** - Create a JSON Schema (or TOML equivalent) that describes the config file structure. This enables:
    - **IDE autocompletion**: Editors like VS Code can suggest valid keys and values as you type

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -34,7 +34,7 @@ mmi/
 │   ├── hook/              # Command approval logic
 │   │   └── hook.go        # Core approval algorithm
 │   ├── config/            # Configuration loading
-│   │   └── config.go      # TOML parsing, includes, profiles
+│   │   └── config.go      # TOML parsing, includes
 │   ├── patterns/          # Pattern utilities
 │   │   └── patterns.go    # Regex building and compilation
 │   ├── audit/             # Audit logging
@@ -126,7 +126,6 @@ type Entry struct {
     Command   string    // The command evaluated
     Approved  bool      // Approval result
     Reason    string    // Pattern name or deny reason
-    Profile   string    // Configuration profile used
 }
 ```
 
@@ -281,13 +280,7 @@ name = "shell builtin"
 | `BuildSubcommandPattern("git", ["status", "log"], [])` | `^git\s+(status\|log)\b` |
 | `BuildWrapperPattern("timeout", ["<arg>"])` | `^timeout\s+(\S+\s+)?` |
 
-### 5.5 Profiles
-
-Alternative configurations stored in `~/.config/mmi/profiles/<name>.toml`:
-- Selected via `--profile NAME` flag or `MMI_PROFILE` env var
-- Completely replaces default config (not merged)
-
-### 5.6 Embedded Default Config
+### 5.5 Embedded Default Config
 
 - Restrictive by design (fail-secure)
 - Used when no config file exists
@@ -312,7 +305,6 @@ Alternative configurations stored in `~/.config/mmi/profiles/<name>.toml`:
 |------|-------------|
 | `-v, --verbose` | Enable debug logging |
 | `--dry-run` | Test commands without JSON output |
-| `--profile NAME` | Use specific config profile |
 | `--no-audit-log` | Disable audit logging |
 
 ### 6.3 Init Command Flags
@@ -390,7 +382,7 @@ Note: `description` and `timeout` in `tool_input` are optional; all other fields
 
 JSON-lines (one JSON object per line):
 ```json
-{"timestamp":"2025-01-15T10:30:00Z","command":"git status","approved":true,"reason":"git","profile":""}
+{"timestamp":"2025-01-15T10:30:00Z","command":"git status","approved":true,"reason":"git"}
 {"timestamp":"2025-01-15T10:30:05Z","command":"sudo rm -rf /","approved":false,"reason":"privilege escalation"}
 ```
 
@@ -402,7 +394,6 @@ JSON-lines (one JSON object per line):
 | `command` | The command evaluated |
 | `approved` | Boolean approval result |
 | `reason` | Pattern name (approved) or deny reason (rejected) |
-| `profile` | Configuration profile used (empty = default) |
 
 ---
 
@@ -430,7 +421,6 @@ JSON-lines (one JSON object per line):
 - Silent failures for unparseable JSON input
 - Explicit rejection for unparseable shell commands
 - Graceful fallback to embedded defaults if config missing
-- Profile specified but not found = error (not fallback)
 
 ---
 
@@ -505,7 +495,6 @@ just ci           # Full CI simulation
 | Variable | Purpose |
 |----------|---------|
 | `MMI_CONFIG` | Custom config directory |
-| `MMI_PROFILE` | Default profile name |
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -46,23 +46,15 @@ Rust development focused configuration:
 - Common Rust tooling
 
 ### strict.toml
-A strict profile that only allows read-only commands.
+A strict configuration that only allows read-only commands.
 Useful for CI environments or when maximum caution is needed.
 
-## Profiles
+## Using Different Configurations
 
-You can also use these as profiles by copying them to the profiles directory:
+To use different configurations for different projects, set the `MMI_CONFIG` environment variable to point to a different config directory:
 
 ```bash
-mkdir -p ~/.config/mmi/profiles
-cp examples/strict.toml ~/.config/mmi/profiles/strict.toml
-```
-
-Then use with:
-```bash
-mmi --profile strict
-# or
-export MMI_PROFILE=strict
+export MMI_CONFIG=/path/to/project/.mmi
 ```
 
 ## Creating Custom Configs

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -17,7 +17,6 @@ type Entry struct {
 	Command   string    `json:"command"`
 	Approved  bool      `json:"approved"`
 	Reason    string    `json:"reason,omitempty"`
-	Profile   string    `json:"profile,omitempty"`
 }
 
 var (

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -151,43 +151,6 @@ func TestLogWhenDisabled(t *testing.T) {
 	}
 }
 
-func TestLogWithProfile(t *testing.T) {
-	defer Reset()
-
-	tmpDir, err := os.MkdirTemp("", "mmi-audit-test-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	logPath := filepath.Join(tmpDir, "audit.log")
-
-	if err := Init(logPath, false); err != nil {
-		t.Fatalf("Init() error = %v", err)
-	}
-
-	entry := Entry{
-		Command:  "git status",
-		Approved: true,
-		Reason:   "git",
-		Profile:  "minimal",
-	}
-	if err := Log(entry); err != nil {
-		t.Errorf("Log() error = %v", err)
-	}
-
-	Close()
-
-	content, err := os.ReadFile(logPath)
-	if err != nil {
-		t.Fatalf("Failed to read log file: %v", err)
-	}
-
-	if !strings.Contains(string(content), `"profile":"minimal"`) {
-		t.Error("Log entry should contain profile")
-	}
-}
-
 func TestClose(t *testing.T) {
 	defer Reset()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,26 +31,7 @@ var (
 	globalConfig *Config
 	// configInitialized tracks whether config has been loaded
 	configInitialized bool
-	// currentProfile is the profile name to use (empty for default)
-	currentProfile string
 )
-
-// SetProfile sets the profile to use for configuration loading.
-// Must be called before Init() to take effect.
-func SetProfile(profile string) {
-	currentProfile = profile
-}
-
-// GetProfile returns the current profile name.
-func GetProfile() string {
-	return currentProfile
-}
-
-// GetProfilePath returns the path to a profile config file.
-// Profiles are stored in ~/.config/mmi/profiles/<name>.toml
-func GetProfilePath(configDir, profile string) string {
-	return filepath.Join(configDir, "profiles", profile+".toml")
-}
 
 // GetConfigDir returns the config directory path.
 // Uses MMI_CONFIG env var if set, otherwise ~/.config/mmi
@@ -369,7 +350,6 @@ func loadEmbeddedDefaults() *Config {
 
 // Init loads configuration from files.
 // If loading fails, it falls back to embedded defaults.
-// If a profile is set via SetProfile(), loads from profiles/<name>.toml instead.
 // Note: This does not auto-create config files. Use EnsureConfigFiles() if needed.
 func Init() error {
 	if configInitialized {
@@ -384,38 +364,17 @@ func Init() error {
 		return err
 	}
 
-	// Determine config path based on profile
-	var configPath string
-	if currentProfile != "" {
-		configPath = GetProfilePath(configDir, currentProfile)
-		logger.Debug("using profile", "profile", currentProfile, "path", configPath)
-	} else {
-		configPath = filepath.Join(configDir, "config.toml")
-	}
+	configPath := filepath.Join(configDir, "config.toml")
 
 	configData, err := os.ReadFile(configPath)
 	if err != nil {
-		if currentProfile != "" {
-			// Profile specified but not found - this is an error
-			logger.Debug("profile not found", "profile", currentProfile, "path", configPath, "error", err)
-			globalConfig = loadEmbeddedDefaults()
-			configInitialized = true
-			return fmt.Errorf("profile %q not found: %w", currentProfile, err)
-		}
-		// Default config not found - use embedded
 		logger.Debug("failed to read config file, using embedded defaults", "path", configPath, "error", err)
 		globalConfig = loadEmbeddedDefaults()
 		configInitialized = true
 		return fmt.Errorf("failed to read config.toml: %w", err)
 	}
 
-	// For profiles, use the profiles directory for includes
-	includeDir := configDir
-	if currentProfile != "" {
-		includeDir = filepath.Join(configDir, "profiles")
-	}
-
-	globalConfig, err = LoadConfigWithDir(configData, includeDir)
+	globalConfig, err = LoadConfigWithDir(configData, configDir)
 	if err != nil {
 		logger.Debug("failed to parse config, using embedded defaults", "error", err)
 		globalConfig = loadEmbeddedDefaults()
@@ -425,7 +384,6 @@ func Init() error {
 
 	logger.Debug("config loaded successfully",
 		"path", configPath,
-		"profile", currentProfile,
 		"wrappers", len(globalConfig.WrapperPatterns),
 		"commands", len(globalConfig.SafeCommands))
 	configInitialized = true
@@ -445,7 +403,6 @@ func Get() *Config {
 func Reset() {
 	configInitialized = false
 	globalConfig = nil
-	currentProfile = ""
 }
 
 // GetDefaultConfig returns the embedded default configuration.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -101,30 +101,6 @@ name = "rm root"
 	}
 }
 
-func TestGetProfilePath(t *testing.T) {
-	path := GetProfilePath("/home/user/.config/mmi", "strict")
-	expected := "/home/user/.config/mmi/profiles/strict.toml"
-	if path != expected {
-		t.Errorf("expected %q, got %q", expected, path)
-	}
-}
-
-func TestSetProfile(t *testing.T) {
-	// Reset state
-	Reset()
-
-	SetProfile("test-profile")
-	if GetProfile() != "test-profile" {
-		t.Errorf("expected profile to be 'test-profile', got %q", GetProfile())
-	}
-
-	// Reset clears profile
-	Reset()
-	if GetProfile() != "" {
-		t.Errorf("expected profile to be empty after reset, got %q", GetProfile())
-	}
-}
-
 // Validation tests
 
 func TestValidateSimpleCommandsMissing(t *testing.T) {

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -61,14 +61,6 @@ type byteRange struct {
 	start, end int
 }
 
-// currentProfile holds the current profile name for audit logging
-var currentProfile string
-
-// SetProfile sets the current profile name for audit logging.
-func SetProfile(profile string) {
-	currentProfile = profile
-}
-
 // findQuotedHeredocRanges parses a command and returns byte ranges of heredoc content
 // where the delimiter is quoted (single or double quotes). Quoted heredocs don't perform
 // shell expansion, so backticks and $() inside them are literal text, not command substitution.
@@ -249,7 +241,6 @@ func logAudit(command string, approved bool, reason string) {
 		Command:  command,
 		Approved: approved,
 		Reason:   reason,
-		Profile:  currentProfile,
 	})
 }
 


### PR DESCRIPTION
The profiles feature (--profile flag and MMI_PROFILE env var) is removed because the same functionality can be achieved using the MMI_CONFIG environment variable to point to different config directories.

Changes:
- Remove --profile flag and MMI_PROFILE env var handling from cmd/root.go
- Remove SetProfile, GetProfile, GetProfilePath from internal/config/config.go
- Remove Profile field from audit.Entry struct
- Remove SetProfile from internal/hook/hook.go
- Update all related tests
- Update documentation to use MMI_CONFIG for different configurations