### PR TITLE
Add automatic Claude Code hook configuration to init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,15 +36,18 @@ Pre-built binaries for Linux, macOS, and Windows are available on the [Releases]
 ## Quick Start
 
 1. Install `mmi` (see above)
-2. Run `mmi init` to create a default configuration file
-3. Add `mmi` as a hook in your Claude Code settings
-4. (Optional) Include an example config for your language stack (see [Example Configurations](#example-configurations))
+2. Run `mmi init` to create the configuration and set up the Claude Code hook
+3. (Optional) Include an example config for your language stack (see [Example Configurations](#example-configurations))
+
+The `mmi init` command automatically:
+- Creates a default configuration file at `~/.config/mmi/config.toml`
+- Configures Claude Code's `~/.claude/settings.json` to use mmi as a PreToolUse hook
 
 ## Configuration
 
 ### Claude Code Hook Setup
 
-Add `mmi` as a PreToolUse hook in your Claude Code settings (`~/.claude/settings.json`):
+Running `mmi init` automatically configures Claude Code's `~/.claude/settings.json` with the mmi hook. If you need to configure it manually, add this to your settings:
 
 ```json
 {
@@ -130,12 +133,20 @@ Run as a hook - reads JSON from stdin, outputs approval JSON to stdout.
 
 ### `mmi init`
 
-Create a default configuration file:
+Create the configuration file and set up the Claude Code hook:
 
 ```bash
-mmi init
-mmi init --force  # Overwrite existing config
+mmi init              # Create config and configure Claude Code
+mmi init --force      # Overwrite existing config
+mmi init --config-only  # Only create config.toml, skip Claude settings
+mmi init --claude-settings /path/to/settings.json  # Use custom settings path
 ```
+
+This command:
+- Creates `~/.config/mmi/config.toml` with default settings
+- Configures `~/.claude/settings.json` to add the mmi PreToolUse hook
+- Preserves existing settings in both files
+- Skips hook configuration if already present
 
 The default config includes basic Unix utilities and shell builtins. For language-specific commands (Python, Node.js, Rust), copy an example config from `examples/`.
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,6 +11,8 @@ import (
 )
 
 var initForce bool
+var initConfigOnly bool
+var initClaudeSettings string
 
 var initCmd = &cobra.Command{
 	Use:   "init",
@@ -19,13 +22,21 @@ var initCmd = &cobra.Command{
 The config file is written to ~/.config/mmi/config.toml (or the path
 specified by MMI_CONFIG environment variable).
 
-Use --force to overwrite an existing configuration file.`,
+By default, this command also configures Claude Code's settings.json to add
+the mmi PreToolUse hook for Bash commands. This enables mmi to intercept
+and validate commands before execution.
+
+Use --force to overwrite an existing configuration file.
+Use --config-only to skip configuring Claude Code settings.
+Use --claude-settings to specify a custom path to Claude's settings.json.`,
 	RunE: runInit,
 }
 
 func init() {
 	rootCmd.AddCommand(initCmd)
 	initCmd.Flags().BoolVarP(&initForce, "force", "f", false, "Overwrite existing config file")
+	initCmd.Flags().BoolVar(&initConfigOnly, "config-only", false, "Only write config.toml, skip Claude settings")
+	initCmd.Flags().StringVar(&initClaudeSettings, "claude-settings", "", "Path to Claude settings.json (default: ~/.claude/settings.json)")
 }
 
 func runInit(cmd *cobra.Command, args []string) error {
@@ -37,22 +48,185 @@ func runInit(cmd *cobra.Command, args []string) error {
 	configPath := filepath.Join(configDir, "config.toml")
 
 	// Check if config already exists
-	if _, err := os.Stat(configPath); err == nil && !initForce {
-		return fmt.Errorf("config file already exists at %s (use --force to overwrite)", configPath)
+	configExists := false
+	if _, err := os.Stat(configPath); err == nil {
+		configExists = true
 	}
+
+	// Handle config file creation/update
+	if configExists && !initForce {
+		fmt.Printf("Config file already exists at %s (use --force to overwrite)\n", configPath)
+	} else {
+		// Create directory if needed
+		if err := os.MkdirAll(configDir, 0755); err != nil {
+			return fmt.Errorf("failed to create config directory: %w", err)
+		}
+
+		// Write default config file
+		if err := os.WriteFile(configPath, config.GetDefaultConfig(), 0644); err != nil {
+			return fmt.Errorf("failed to write config file: %w", err)
+		}
+
+		fmt.Printf("Configuration written to: %s\n", configPath)
+		fmt.Println("Run 'mmi validate' to verify your configuration.")
+	}
+
+	// Configure Claude settings unless --config-only was passed
+	if !initConfigOnly {
+		if err := configureClaudeSettings(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// getClaudeSettingsPath returns the path to Claude's settings.json file.
+// It checks the --claude-settings flag first, then falls back to
+// ~/.claude/settings.json.
+func getClaudeSettingsPath() (string, error) {
+	if initClaudeSettings != "" {
+		return initClaudeSettings, nil
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	return filepath.Join(homeDir, ".claude", "settings.json"), nil
+}
+
+// isMMIHookPresent checks if the mmi hook is already configured in the settings.
+// It looks for a Bash matcher in hooks.PreToolUse that has an mmi command hook.
+func isMMIHookPresent(settings map[string]any) bool {
+	if settings == nil {
+		return false
+	}
+
+	hooks, ok := settings["hooks"].(map[string]any)
+	if !ok {
+		return false
+	}
+
+	preToolUse, ok := hooks["PreToolUse"].([]any)
+	if !ok {
+		return false
+	}
+
+	for _, matcher := range preToolUse {
+		m, ok := matcher.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if m["matcher"] != "Bash" {
+			continue
+		}
+
+		hooksList, ok := m["hooks"].([]any)
+		if !ok {
+			continue
+		}
+
+		for _, hook := range hooksList {
+			h, ok := hook.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			if h["type"] == "command" && h["command"] == "mmi" {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// addMMIHook adds the mmi hook to the settings.
+// It preserves all existing settings and hooks.
+func addMMIHook(settings map[string]any) map[string]any {
+	if settings == nil {
+		settings = make(map[string]any)
+	}
+
+	// Ensure hooks map exists
+	hooks, ok := settings["hooks"].(map[string]any)
+	if !ok {
+		hooks = make(map[string]any)
+		settings["hooks"] = hooks
+	}
+
+	// Ensure PreToolUse array exists
+	preToolUse, ok := hooks["PreToolUse"].([]any)
+	if !ok {
+		preToolUse = []any{}
+	}
+
+	// Create the mmi hook entry
+	mmiHook := map[string]any{
+		"matcher": "Bash",
+		"hooks": []any{
+			map[string]any{
+				"type":    "command",
+				"command": "mmi",
+			},
+		},
+	}
+
+	// Append the new matcher
+	preToolUse = append(preToolUse, mmiHook)
+	hooks["PreToolUse"] = preToolUse
+
+	return settings
+}
+
+// configureClaudeSettings adds the mmi hook to Claude's settings.json.
+// It preserves existing settings and only adds the hook if not already present.
+func configureClaudeSettings() error {
+	settingsPath, err := getClaudeSettingsPath()
+	if err != nil {
+		return err
+	}
+
+	// Read existing settings or start with empty map
+	var settings map[string]any
+	if data, err := os.ReadFile(settingsPath); err == nil {
+		if err := json.Unmarshal(data, &settings); err != nil {
+			return fmt.Errorf("failed to parse Claude settings.json: %w", err)
+		}
+	} else if os.IsNotExist(err) {
+		settings = make(map[string]any)
+	} else {
+		return fmt.Errorf("failed to read Claude settings.json: %w", err)
+	}
+
+	// Check if hook is already present
+	if isMMIHookPresent(settings) {
+		fmt.Printf("Claude Code hook already configured in: %s\n", settingsPath)
+		return nil
+	}
+
+	// Add the hook
+	settings = addMMIHook(settings)
 
 	// Create directory if needed
-	if err := os.MkdirAll(configDir, 0755); err != nil {
-		return fmt.Errorf("failed to create config directory: %w", err)
+	settingsDir := filepath.Dir(settingsPath)
+	if err := os.MkdirAll(settingsDir, 0755); err != nil {
+		return fmt.Errorf("failed to create Claude settings directory: %w", err)
 	}
 
-	// Write default config file
-	if err := os.WriteFile(configPath, config.GetDefaultConfig(), 0644); err != nil {
-		return fmt.Errorf("failed to write config file: %w", err)
+	// Write back with 2-space indentation
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal Claude settings: %w", err)
 	}
 
-	fmt.Printf("Configuration written to: %s\n", configPath)
-	fmt.Println("Run 'mmi validate' to verify your configuration.")
+	if err := os.WriteFile(settingsPath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write Claude settings.json: %w", err)
+	}
 
+	fmt.Printf("Claude Code hook configured in: %s\n", settingsPath)
 	return nil
 }

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -55,7 +56,7 @@ func TestRunInitCreatesConfigFile(t *testing.T) {
 	}
 }
 
-func TestRunInitFailsWhenConfigExists(t *testing.T) {
+func TestRunInitWithExistingConfigPrintsNotice(t *testing.T) {
 	resetGlobalState()
 
 	// Create temp directory with existing config
@@ -70,27 +71,25 @@ func TestRunInitFailsWhenConfigExists(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Set up Claude settings path
+	claudeDir := filepath.Join(tmpDir, ".claude")
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	initClaudeSettings = settingsPath
+
 	// Create a command for testing
 	cmd := &cobra.Command{}
 	var stdout, stderr bytes.Buffer
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stderr)
 
-	// Reset force flag
+	// Reset flags
 	initForce = false
+	initConfigOnly = false
 
-	// Run init - should fail
+	// Run init - should succeed (prints notice but no error)
 	err := runInit(cmd, []string{})
-	if err == nil {
-		t.Fatal("expected error when config exists, got nil")
-	}
-
-	if !strings.Contains(err.Error(), "already exists") {
-		t.Errorf("error should mention 'already exists', got: %v", err)
-	}
-
-	if !strings.Contains(err.Error(), "--force") {
-		t.Errorf("error should mention '--force', got: %v", err)
+	if err != nil {
+		t.Fatalf("expected no error when config exists, got: %v", err)
 	}
 
 	// Verify original content was not modified
@@ -100,6 +99,145 @@ func TestRunInitFailsWhenConfigExists(t *testing.T) {
 	}
 	if !bytes.Equal(content, existingContent) {
 		t.Error("existing config file was modified")
+	}
+
+	// Verify Claude settings were configured
+	if _, err := os.Stat(settingsPath); os.IsNotExist(err) {
+		t.Error("settings.json was not created")
+	}
+
+	// Verify mmi hook is in settings
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("failed to read settings.json: %v", err)
+	}
+
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("failed to parse settings.json: %v", err)
+	}
+
+	if !isMMIHookPresent(settings) {
+		t.Error("mmi hook not found in settings.json")
+	}
+}
+
+func TestRunInitWithExistingConfigConfiguresClaudeSettings(t *testing.T) {
+	resetGlobalState()
+
+	// Create temp directory with existing config
+	tmpDir := t.TempDir()
+	os.Setenv("MMI_CONFIG", tmpDir)
+	defer os.Unsetenv("MMI_CONFIG")
+
+	// Create existing config file with custom content
+	configPath := filepath.Join(tmpDir, "config.toml")
+	existingContent := []byte("# custom config that should be preserved\n[patterns]\nallowed = [\"echo *\"]\n")
+	if err := os.WriteFile(configPath, existingContent, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set up Claude settings path with empty settings file
+	claudeDir := filepath.Join(tmpDir, ".claude")
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	initClaudeSettings = settingsPath
+
+	// Create empty settings.json
+	if err := os.MkdirAll(claudeDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(settingsPath, []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &cobra.Command{}
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	// Reset flags - no force, no config-only
+	initForce = false
+	initConfigOnly = false
+
+	// Run init without --force
+	err := runInit(cmd, []string{})
+	if err != nil {
+		t.Fatalf("runInit() error = %v", err)
+	}
+
+	// Verify config.toml was NOT modified
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read config file: %v", err)
+	}
+	if !bytes.Equal(content, existingContent) {
+		t.Errorf("config.toml was modified:\ngot: %s\nwant: %s", content, existingContent)
+	}
+
+	// Verify settings.json now has mmi hook
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("failed to read settings.json: %v", err)
+	}
+
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("failed to parse settings.json: %v", err)
+	}
+
+	if !isMMIHookPresent(settings) {
+		t.Error("mmi hook not found in settings.json after init without --force")
+	}
+}
+
+func TestRunInitWithExistingConfigAndConfigOnlySkipsClaudeSettings(t *testing.T) {
+	resetGlobalState()
+
+	// Create temp directory with existing config
+	tmpDir := t.TempDir()
+	os.Setenv("MMI_CONFIG", tmpDir)
+	defer os.Unsetenv("MMI_CONFIG")
+
+	// Create existing config file
+	configPath := filepath.Join(tmpDir, "config.toml")
+	existingContent := []byte("# existing config")
+	if err := os.WriteFile(configPath, existingContent, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set up Claude settings path
+	claudeDir := filepath.Join(tmpDir, ".claude")
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	initClaudeSettings = settingsPath
+
+	cmd := &cobra.Command{}
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	// Set config-only flag
+	initForce = false
+	initConfigOnly = true
+	defer func() { initConfigOnly = false }()
+
+	// Run init with --config-only
+	err := runInit(cmd, []string{})
+	if err != nil {
+		t.Fatalf("runInit() error = %v", err)
+	}
+
+	// Verify config.toml was NOT modified
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read config file: %v", err)
+	}
+	if !bytes.Equal(content, existingContent) {
+		t.Error("config.toml was modified with --config-only")
+	}
+
+	// Verify settings.json was NOT created (--config-only skips Claude settings)
+	if _, err := os.Stat(settingsPath); !os.IsNotExist(err) {
+		t.Error("settings.json should not be created with --config-only")
 	}
 }
 
@@ -210,5 +348,688 @@ func TestInitCmdUsage(t *testing.T) {
 
 	if initCmd.Long == "" {
 		t.Error("initCmd.Long should not be empty")
+	}
+}
+
+// Tests for Claude settings functionality
+
+func TestInitCmdHasConfigOnlyFlag(t *testing.T) {
+	flag := initCmd.Flags().Lookup("config-only")
+	if flag == nil {
+		t.Fatal("init command should have --config-only flag")
+	}
+
+	if flag.DefValue != "false" {
+		t.Errorf("--config-only flag default = %q, want 'false'", flag.DefValue)
+	}
+}
+
+func TestInitCmdHasClaudeSettingsFlag(t *testing.T) {
+	flag := initCmd.Flags().Lookup("claude-settings")
+	if flag == nil {
+		t.Fatal("init command should have --claude-settings flag")
+	}
+
+	if flag.DefValue != "" {
+		t.Errorf("--claude-settings flag default = %q, want empty string", flag.DefValue)
+	}
+}
+
+func TestRunInitWithConfigOnlySkipsSettings(t *testing.T) {
+	resetGlobalState()
+
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "mmi")
+	claudeDir := filepath.Join(tmpDir, ".claude")
+
+	os.Setenv("MMI_CONFIG", configDir)
+	defer os.Unsetenv("MMI_CONFIG")
+	initClaudeSettings = filepath.Join(claudeDir, "settings.json")
+
+	cmd := &cobra.Command{}
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	initForce = false
+	initConfigOnly = true
+	defer func() { initConfigOnly = false }()
+
+	err := runInit(cmd, []string{})
+	if err != nil {
+		t.Fatalf("runInit() error = %v", err)
+	}
+
+	// Verify config.toml was created
+	configPath := filepath.Join(configDir, "config.toml")
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		t.Error("config file was not created")
+	}
+
+	// Verify settings.json was NOT created
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	if _, err := os.Stat(settingsPath); !os.IsNotExist(err) {
+		t.Error("settings.json should not be created with --config-only")
+	}
+}
+
+func TestRunInitConfiguresClaudeSettings(t *testing.T) {
+	resetGlobalState()
+
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "mmi")
+	claudeDir := filepath.Join(tmpDir, ".claude")
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+
+	os.Setenv("MMI_CONFIG", configDir)
+	defer os.Unsetenv("MMI_CONFIG")
+	initClaudeSettings = settingsPath
+
+	cmd := &cobra.Command{}
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	initForce = false
+	initConfigOnly = false
+
+	err := runInit(cmd, []string{})
+	if err != nil {
+		t.Fatalf("runInit() error = %v", err)
+	}
+
+	// Verify config.toml was created
+	configPath := filepath.Join(configDir, "config.toml")
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		t.Error("config file was not created")
+	}
+
+	// Verify settings.json was created
+	if _, err := os.Stat(settingsPath); os.IsNotExist(err) {
+		t.Error("settings.json was not created")
+	}
+
+	// Verify mmi hook is in settings
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("failed to read settings.json: %v", err)
+	}
+
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("failed to parse settings.json: %v", err)
+	}
+
+	if !isMMIHookPresent(settings) {
+		t.Error("mmi hook not found in settings.json")
+	}
+}
+
+func TestRunInitPreservesExistingSettings(t *testing.T) {
+	resetGlobalState()
+
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "mmi")
+	claudeDir := filepath.Join(tmpDir, ".claude")
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+
+	os.Setenv("MMI_CONFIG", configDir)
+	defer os.Unsetenv("MMI_CONFIG")
+	initClaudeSettings = settingsPath
+
+	// Create existing settings with other keys
+	if err := os.MkdirAll(claudeDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	existingSettings := map[string]any{
+		"someOtherSetting": "value",
+		"nested": map[string]any{
+			"key": "value",
+		},
+	}
+	data, _ := json.MarshalIndent(existingSettings, "", "  ")
+	if err := os.WriteFile(settingsPath, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &cobra.Command{}
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	initForce = false
+	initConfigOnly = false
+
+	err := runInit(cmd, []string{})
+	if err != nil {
+		t.Fatalf("runInit() error = %v", err)
+	}
+
+	// Read back settings
+	data, err = os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("failed to read settings.json: %v", err)
+	}
+
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("failed to parse settings.json: %v", err)
+	}
+
+	// Verify existing settings are preserved
+	if settings["someOtherSetting"] != "value" {
+		t.Error("existing setting 'someOtherSetting' was not preserved")
+	}
+
+	nested, ok := settings["nested"].(map[string]any)
+	if !ok || nested["key"] != "value" {
+		t.Error("existing nested setting was not preserved")
+	}
+
+	// Verify mmi hook was added
+	if !isMMIHookPresent(settings) {
+		t.Error("mmi hook was not added to existing settings")
+	}
+}
+
+func TestRunInitPreservesOtherHooks(t *testing.T) {
+	resetGlobalState()
+
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "mmi")
+	claudeDir := filepath.Join(tmpDir, ".claude")
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+
+	os.Setenv("MMI_CONFIG", configDir)
+	defer os.Unsetenv("MMI_CONFIG")
+	initClaudeSettings = settingsPath
+
+	// Create existing settings with other PreToolUse hooks
+	if err := os.MkdirAll(claudeDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	existingSettings := map[string]any{
+		"hooks": map[string]any{
+			"PreToolUse": []any{
+				map[string]any{
+					"matcher": "Edit",
+					"hooks": []any{
+						map[string]any{
+							"type":    "command",
+							"command": "other-tool",
+						},
+					},
+				},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(existingSettings, "", "  ")
+	if err := os.WriteFile(settingsPath, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &cobra.Command{}
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	initForce = false
+	initConfigOnly = false
+
+	err := runInit(cmd, []string{})
+	if err != nil {
+		t.Fatalf("runInit() error = %v", err)
+	}
+
+	// Read back settings
+	data, err = os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("failed to read settings.json: %v", err)
+	}
+
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("failed to parse settings.json: %v", err)
+	}
+
+	// Verify mmi hook was added
+	if !isMMIHookPresent(settings) {
+		t.Error("mmi hook was not added")
+	}
+
+	// Verify other hooks are preserved
+	hooks := settings["hooks"].(map[string]any)
+	preToolUse := hooks["PreToolUse"].([]any)
+
+	// Should have 2 matchers now
+	if len(preToolUse) != 2 {
+		t.Errorf("expected 2 PreToolUse matchers, got %d", len(preToolUse))
+	}
+
+	// Find the Edit matcher
+	foundEdit := false
+	for _, matcher := range preToolUse {
+		m := matcher.(map[string]any)
+		if m["matcher"] == "Edit" {
+			foundEdit = true
+			break
+		}
+	}
+	if !foundEdit {
+		t.Error("existing Edit matcher was not preserved")
+	}
+}
+
+func TestRunInitSkipsWhenHookPresent(t *testing.T) {
+	resetGlobalState()
+
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "mmi")
+	claudeDir := filepath.Join(tmpDir, ".claude")
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+
+	os.Setenv("MMI_CONFIG", configDir)
+	defer os.Unsetenv("MMI_CONFIG")
+	initClaudeSettings = settingsPath
+
+	// Create existing settings with mmi hook already present
+	if err := os.MkdirAll(claudeDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	existingSettings := map[string]any{
+		"hooks": map[string]any{
+			"PreToolUse": []any{
+				map[string]any{
+					"matcher": "Bash",
+					"hooks": []any{
+						map[string]any{
+							"type":    "command",
+							"command": "mmi",
+						},
+					},
+				},
+			},
+		},
+	}
+	originalData, _ := json.MarshalIndent(existingSettings, "", "  ")
+	if err := os.WriteFile(settingsPath, originalData, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Get original mod time
+	originalInfo, _ := os.Stat(settingsPath)
+	originalModTime := originalInfo.ModTime()
+
+	cmd := &cobra.Command{}
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+
+	initForce = false
+	initConfigOnly = false
+
+	err := runInit(cmd, []string{})
+	if err != nil {
+		t.Fatalf("runInit() error = %v", err)
+	}
+
+	// Verify file was not modified (by checking content is identical)
+	newData, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("failed to read settings.json: %v", err)
+	}
+
+	// Check content is unchanged
+	if !bytes.Equal(originalData, newData) {
+		t.Error("settings.json was modified when hook was already present")
+	}
+
+	// Also check mod time wasn't updated (file wasn't rewritten)
+	newInfo, _ := os.Stat(settingsPath)
+	if !newInfo.ModTime().Equal(originalModTime) {
+		t.Error("settings.json mod time changed when hook was already present")
+	}
+}
+
+func TestRunInitCreatesClaudeDir(t *testing.T) {
+	resetGlobalState()
+
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "mmi")
+	claudeDir := filepath.Join(tmpDir, "nested", "path", ".claude")
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+
+	os.Setenv("MMI_CONFIG", configDir)
+	defer os.Unsetenv("MMI_CONFIG")
+	initClaudeSettings = settingsPath
+
+	cmd := &cobra.Command{}
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	initForce = false
+	initConfigOnly = false
+
+	err := runInit(cmd, []string{})
+	if err != nil {
+		t.Fatalf("runInit() error = %v", err)
+	}
+
+	// Verify claude directory was created
+	if _, err := os.Stat(claudeDir); os.IsNotExist(err) {
+		t.Error("claude directory was not created")
+	}
+
+	// Verify settings.json was created
+	if _, err := os.Stat(settingsPath); os.IsNotExist(err) {
+		t.Error("settings.json was not created")
+	}
+}
+
+func TestRunInitHandlesInvalidJSON(t *testing.T) {
+	resetGlobalState()
+
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "mmi")
+	claudeDir := filepath.Join(tmpDir, ".claude")
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+
+	os.Setenv("MMI_CONFIG", configDir)
+	defer os.Unsetenv("MMI_CONFIG")
+	initClaudeSettings = settingsPath
+
+	// Create existing settings with invalid JSON
+	if err := os.MkdirAll(claudeDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(settingsPath, []byte("{ invalid json }"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &cobra.Command{}
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	initForce = false
+	initConfigOnly = false
+
+	err := runInit(cmd, []string{})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "parse") && !strings.Contains(err.Error(), "JSON") && !strings.Contains(err.Error(), "invalid") {
+		t.Errorf("error should mention parsing issue, got: %v", err)
+	}
+}
+
+// Unit tests for helper functions
+
+func TestIsMMIHookPresent(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings map[string]any
+		want     bool
+	}{
+		{
+			name:     "empty settings",
+			settings: map[string]any{},
+			want:     false,
+		},
+		{
+			name:     "nil settings",
+			settings: nil,
+			want:     false,
+		},
+		{
+			name: "no hooks key",
+			settings: map[string]any{
+				"otherKey": "value",
+			},
+			want: false,
+		},
+		{
+			name: "hooks but no PreToolUse",
+			settings: map[string]any{
+				"hooks": map[string]any{
+					"PostToolUse": []any{},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "PreToolUse but no Bash matcher",
+			settings: map[string]any{
+				"hooks": map[string]any{
+					"PreToolUse": []any{
+						map[string]any{
+							"matcher": "Edit",
+							"hooks":   []any{},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Bash matcher but no mmi hook",
+			settings: map[string]any{
+				"hooks": map[string]any{
+					"PreToolUse": []any{
+						map[string]any{
+							"matcher": "Bash",
+							"hooks": []any{
+								map[string]any{
+									"type":    "command",
+									"command": "other-tool",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "mmi hook present",
+			settings: map[string]any{
+				"hooks": map[string]any{
+					"PreToolUse": []any{
+						map[string]any{
+							"matcher": "Bash",
+							"hooks": []any{
+								map[string]any{
+									"type":    "command",
+									"command": "mmi",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "mmi hook present among other hooks",
+			settings: map[string]any{
+				"hooks": map[string]any{
+					"PreToolUse": []any{
+						map[string]any{
+							"matcher": "Bash",
+							"hooks": []any{
+								map[string]any{
+									"type":    "command",
+									"command": "other-tool",
+								},
+								map[string]any{
+									"type":    "command",
+									"command": "mmi",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "mmi hook in different Bash matcher",
+			settings: map[string]any{
+				"hooks": map[string]any{
+					"PreToolUse": []any{
+						map[string]any{
+							"matcher": "Edit",
+							"hooks":   []any{},
+						},
+						map[string]any{
+							"matcher": "Bash",
+							"hooks": []any{
+								map[string]any{
+									"type":    "command",
+									"command": "mmi",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isMMIHookPresent(tt.settings)
+			if got != tt.want {
+				t.Errorf("isMMIHookPresent() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAddMMIHook(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings map[string]any
+	}{
+		{
+			name:     "empty settings",
+			settings: map[string]any{},
+		},
+		{
+			name:     "nil settings",
+			settings: nil,
+		},
+		{
+			name: "existing other settings",
+			settings: map[string]any{
+				"otherKey": "value",
+			},
+		},
+		{
+			name: "existing hooks but no PreToolUse",
+			settings: map[string]any{
+				"hooks": map[string]any{
+					"PostToolUse": []any{
+						map[string]any{
+							"matcher": "Bash",
+							"hooks":   []any{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "existing PreToolUse with other matchers",
+			settings: map[string]any{
+				"hooks": map[string]any{
+					"PreToolUse": []any{
+						map[string]any{
+							"matcher": "Edit",
+							"hooks": []any{
+								map[string]any{
+									"type":    "command",
+									"command": "other-tool",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := addMMIHook(tt.settings)
+
+			// Verify the hook was added
+			if !isMMIHookPresent(result) {
+				t.Error("mmi hook should be present after addMMIHook")
+			}
+
+			// Verify existing settings are preserved
+			if tt.settings != nil {
+				if v, ok := tt.settings["otherKey"]; ok {
+					if result["otherKey"] != v {
+						t.Error("existing settings should be preserved")
+					}
+				}
+			}
+
+			// Verify existing hooks are preserved
+			if tt.settings != nil {
+				if hooks, ok := tt.settings["hooks"].(map[string]any); ok {
+					if postToolUse, ok := hooks["PostToolUse"]; ok {
+						resultHooks := result["hooks"].(map[string]any)
+						if resultHooks["PostToolUse"] == nil {
+							t.Error("existing PostToolUse hooks should be preserved")
+						}
+						_ = postToolUse // use the variable
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestAddMMIHookPreservesExistingMatchers(t *testing.T) {
+	settings := map[string]any{
+		"hooks": map[string]any{
+			"PreToolUse": []any{
+				map[string]any{
+					"matcher": "Edit",
+					"hooks": []any{
+						map[string]any{
+							"type":    "command",
+							"command": "other-tool",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := addMMIHook(settings)
+
+	hooks := result["hooks"].(map[string]any)
+	preToolUse := hooks["PreToolUse"].([]any)
+
+	if len(preToolUse) != 2 {
+		t.Errorf("expected 2 PreToolUse matchers, got %d", len(preToolUse))
+	}
+
+	// Verify Edit matcher is still there
+	foundEdit := false
+	for _, matcher := range preToolUse {
+		m := matcher.(map[string]any)
+		if m["matcher"] == "Edit" {
+			foundEdit = true
+			break
+		}
+	}
+	if !foundEdit {
+		t.Error("existing Edit matcher should be preserved")
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -14,6 +14,7 @@ func resetGlobalState() {
 	verbose = false
 	dryRun = false
 	noAuditLog = false
+	initClaudeSettings = ""
 	config.Reset()
 }
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -331,6 +331,8 @@ name = "shell builtin"
 | Flag | Description |
 |------|-------------|
 | `-f, --force` | Overwrite existing config file |
+| `--config-only` | Only write config.toml, skip Claude settings configuration |
+| `--claude-settings` | Path to Claude settings.json (default: ~/.claude/settings.json) |
 
 ---
 
@@ -338,7 +340,8 @@ name = "shell builtin"
 
 ### 7.1 Hook Configuration
 
-Add to `~/.claude/settings.json`:
+Running `mmi init` automatically configures Claude Code's `~/.claude/settings.json` to add the mmi hook. The configuration added:
+
 ```json
 {
   "hooks": {
@@ -352,6 +355,13 @@ Add to `~/.claude/settings.json`:
   }
 }
 ```
+
+**Automatic configuration behavior:**
+- Preserves all existing settings in `settings.json`
+- Creates `~/.claude/` directory if it doesn't exist
+- Skips configuration if mmi hook is already present
+- Use `--config-only` to skip this step
+- Use `--claude-settings` to specify a custom settings.json path
 
 ### 7.2 Hook Protocol
 


### PR DESCRIPTION
## Summary
- The `mmi init` command now automatically configures `~/.claude/settings.json` to add the mmi PreToolUse hook
- Added `--config-only` flag to skip Claude settings configuration
- Added `--claude-settings` flag to specify a custom settings.json path
- Implementation preserves existing settings and hooks, and skips if hook is already present