### PR TITLE
Add original JSON input to audit log

### DIFF
--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -30,6 +30,7 @@ type Entry struct {
 	Approved   bool      `json:"approved"`
 	Segments   []Segment `json:"segments"`
 	Cwd        string    `json:"cwd"`
+	Input      string    `json:"input"`
 }
 
 // Segment represents a single command segment within a chained command.


### PR DESCRIPTION
## Summary
- Add `input` field to audit log entries to store the raw JSON input from Claude
- Enables debugging of JSON parsing errors by showing what Claude actually sent
- Read raw bytes before parsing to capture original input