### PR TITLE
Add magic values to constants refactoring plan

### DIFF
--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/dgerlanc/mmi/internal/constants"
 	"github.com/dgerlanc/mmi/internal/logger"
 )
 
@@ -18,6 +19,9 @@ const (
 	CodeDenyMatch           = "DENY_MATCH"
 	CodeNoMatch             = "NO_MATCH"
 )
+
+// TimestampFormat is the format used for audit log timestamps.
+const TimestampFormat = "2006-01-02T15:04:05.0Z07:00"
 
 // Entry represents a single audit log entry (v1 format).
 type Entry struct {
@@ -95,13 +99,13 @@ func Init(path string, disable bool) error {
 
 	// Create directory if it doesn't exist
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, constants.DirMode); err != nil {
 		logger.Debug("failed to create audit log directory", "error", err)
 		return err
 	}
 
 	// Open audit log file in append mode
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, constants.FileMode)
 	if err != nil {
 		logger.Debug("failed to open audit log file", "error", err)
 		return err
@@ -138,7 +142,7 @@ func Log(entry Entry) error {
 	}
 
 	// Format timestamp with tenths of second precision (1 decimal place)
-	entry.Timestamp = time.Now().UTC().Format("2006-01-02T15:04:05.0Z07:00")
+	entry.Timestamp = time.Now().UTC().Format(TimestampFormat)
 
 	data, err := json.Marshal(entry)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 
 	"github.com/BurntSushi/toml"
+	"github.com/dgerlanc/mmi/internal/constants"
 	"github.com/dgerlanc/mmi/internal/logger"
 	"github.com/dgerlanc/mmi/internal/patterns"
 )
@@ -36,7 +37,7 @@ var (
 // GetConfigDir returns the config directory path.
 // Uses MMI_CONFIG env var if set, otherwise ~/.config/mmi
 func GetConfigDir() (string, error) {
-	if dir := os.Getenv("MMI_CONFIG"); dir != "" {
+	if dir := os.Getenv(constants.EnvConfigDir); dir != "" {
 		return dir, nil
 	}
 
@@ -44,20 +45,20 @@ func GetConfigDir() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to get home directory: %w", err)
 	}
-	return filepath.Join(home, ".config", "mmi"), nil
+	return filepath.Join(home, constants.XDGConfigSubdir, constants.AppName), nil
 }
 
 // EnsureConfigFiles creates the config directory and writes default config file if it doesn't exist.
 func EnsureConfigFiles(configDir string) error {
 	// Create config directory if it doesn't exist
-	if err := os.MkdirAll(configDir, 0755); err != nil {
+	if err := os.MkdirAll(configDir, constants.DirMode); err != nil {
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}
 
 	// Write default config.toml if it doesn't exist
-	configPath := filepath.Join(configDir, "config.toml")
+	configPath := filepath.Join(configDir, constants.ConfigFileName)
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		if err := os.WriteFile(configPath, defaultConfig, 0644); err != nil {
+		if err := os.WriteFile(configPath, defaultConfig, constants.FileMode); err != nil {
 			return fmt.Errorf("failed to write config.toml: %w", err)
 		}
 	}
@@ -364,7 +365,7 @@ func Init() error {
 		return err
 	}
 
-	configPath := filepath.Join(configDir, "config.toml")
+	configPath := filepath.Join(configDir, constants.ConfigFileName)
 
 	configData, err := os.ReadFile(configPath)
 	if err != nil {

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -1,0 +1,22 @@
+// Package constants defines shared constants used across the mmi codebase.
+package constants
+
+import "os"
+
+// File permissions
+const (
+	DirMode  os.FileMode = 0755
+	FileMode os.FileMode = 0644
+)
+
+// Environment variables
+const EnvConfigDir = "MMI_CONFIG"
+
+// Application paths
+const (
+	AppName            = "mmi"
+	XDGConfigSubdir    = ".config"
+	ClaudeConfigDir    = ".claude"
+	ClaudeSettingsFile = "settings.json"
+	ConfigFileName     = "config.toml"
+)

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -16,6 +16,21 @@ import (
 	"mvdan.cc/sh/v3/syntax"
 )
 
+// Tool names
+const ToolNameBash = "Bash"
+
+// Hook event names
+const EventPreToolUse = "PreToolUse"
+
+// Permission decisions
+const (
+	DecisionAllow = "allow"
+	DecisionAsk   = "ask"
+)
+
+// Audit log version
+const AuditVersion = 1
+
 // Result contains the outcome of processing a command.
 type Result struct {
 	Command  string // The command that was processed
@@ -175,7 +190,7 @@ func ProcessWithResult(r io.Reader) Result {
 		return Result{Output: output}
 	}
 
-	if input.ToolName != "Bash" {
+	if input.ToolName != ToolNameBash {
 		logger.Debug("not a Bash command", "tool", input.ToolName)
 		output := FormatAsk("not a Bash command")
 		return Result{Output: output}
@@ -344,7 +359,7 @@ func CheckDeny(cmd string, denyPatterns []patterns.Pattern) DenyResult {
 // logAudit logs a command decision to the audit log.
 func logAudit(command string, approved bool, segments []audit.Segment, durationMs float64, sessionID, toolUseID, cwd, rawInput, rawOutput string) {
 	audit.Log(audit.Entry{
-		Version:    1,
+		Version:    AuditVersion,
 		SessionID:  sessionID,
 		ToolUseID:  toolUseID,
 		Command:    command,
@@ -361,8 +376,8 @@ func logAudit(command string, approved bool, segments []audit.Segment, durationM
 func FormatApproval(reason string) string {
 	output := Output{
 		HookSpecificOutput: SpecificOutput{
-			HookEventName:            "PreToolUse",
-			PermissionDecision:       "allow",
+			HookEventName:            EventPreToolUse,
+			PermissionDecision:       DecisionAllow,
 			PermissionDecisionReason: reason,
 		},
 	}
@@ -378,8 +393,8 @@ func FormatApproval(reason string) string {
 func FormatAsk(reason string) string {
 	output := Output{
 		HookSpecificOutput: SpecificOutput{
-			HookEventName:            "PreToolUse",
-			PermissionDecision:       "ask",
+			HookEventName:            EventPreToolUse,
+			PermissionDecision:       DecisionAsk,
 			PermissionDecisionReason: reason,
 		},
 	}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/dgerlanc/mmi/internal/config"
+	"github.com/dgerlanc/mmi/internal/constants"
 )
 
 // SetupTestConfig creates a temporary config directory with test configuration.
@@ -15,11 +16,11 @@ func SetupTestConfig(t *testing.T, configContent string) func() {
 	t.Helper()
 
 	tmpDir := t.TempDir()
-	os.Setenv("MMI_CONFIG", tmpDir)
+	os.Setenv(constants.EnvConfigDir, tmpDir)
 
 	if configContent != "" {
-		configPath := filepath.Join(tmpDir, "config.toml")
-		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		configPath := filepath.Join(tmpDir, constants.ConfigFileName)
+		if err := os.WriteFile(configPath, []byte(configContent), constants.FileMode); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -28,7 +29,7 @@ func SetupTestConfig(t *testing.T, configContent string) func() {
 	config.Init()
 
 	return func() {
-		os.Unsetenv("MMI_CONFIG")
+		os.Unsetenv(constants.EnvConfigDir)
 		config.Reset()
 	}
 }


### PR DESCRIPTION
Document identifies hardcoded literals that should be replaced with
named constants, organized by priority:

- Phase 1 (high): File permissions, env vars, tool/event names
- Phase 2 (medium): Path components, JSON fields, decisions
- Phase 3 (lower): Config section types, audit version

Includes implementation steps and success metrics.