### PR TITLE
Return deny instead of ask for commands matching deny list

### DIFF
--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -227,12 +227,12 @@ func TestRunHookNormalModeRejectedSilent(t *testing.T) {
 	io.Copy(&buf, stdoutR)
 	output := buf.String()
 
-	// Rejected commands produce ask JSON output
+	// Commands matching deny list produce deny JSON output
 	if output == "" {
-		t.Errorf("expected ask output for rejected command, got nothing")
+		t.Errorf("expected deny output for rejected command, got nothing")
 	}
-	if !strings.Contains(output, `"permissionDecision":"ask"`) {
-		t.Errorf("expected ask permission decision, got: %s", output)
+	if !strings.Contains(output, `"permissionDecision":"deny"`) {
+		t.Errorf("expected deny permission decision, got: %s", output)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Commands matching the deny list now return `permissionDecision:"deny"` instead of `"ask"`
- This blocks denied commands outright rather than prompting the user to approve them
- Added `DecisionDeny` constant and `FormatDeny` function
- Updated test to expect the new behavior

## Reproducer

```bash
# Before (main): returns "ask"
echo '{"tool_name":"Bash","tool_input":{"command":"sudo whoami"}}' | mmi
# {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask",...}}

# After (this PR): returns "deny" 
echo '{"tool_name":"Bash","tool_input":{"command":"sudo whoami"}}' | mmi
# {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny",...}}
```

## Test plan

- [x] All existing tests pass
- [x] Updated `TestRunHookNormalModeRejectedSilent` to expect `deny` for deny-list matches
- [x] Manual testing with `sudo` and `rm -rf /` commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)