### PR TITLE
Add Homebrew tap support via GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,3 +31,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,12 +63,16 @@ release:
 
     Mother May I? - Claude Code Bash command approval hook
 
-# homebrew_casks:
-#   - name: mmi
-#     repository:
-#       owner: dgerlanc
-#       name: homebrew-tap
-#     homepage: https://github.com/dgerlanc/mmi
-#     description: Claude Code Bash command approval hook
-#     binaries:
-#       - mmi
+brews:
+  - name: mmi
+    repository:
+      owner: dgerlanc
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    homepage: https://github.com/dgerlanc/mmi
+    description: "Claude Code Bash command approval hook"
+    license: "Apache-2.0"
+    install: |
+      bin.install "mmi"
+    test: |
+      system "#{bin}/mmi", "--version"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ This project was inspired by this [post](https://matthewrocklin.com/ai-zealotry/
 
 ## Installation
 
+### Homebrew (macOS and Linux)
+
+```bash
+brew install dgerlanc/tap/mmi
+```
+
 ### From Source
 
 ``` bash

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -600,13 +600,17 @@ just ci           # Full CI simulation
 - Stripped binaries with version info via ldflags
 - CGO disabled for static builds
 - GitHub Releases with auto-generated changelog
-- Homebrew tap: `dgerlanc/homebrew-tap`
+- Homebrew tap: `dgerlanc/homebrew-tap` (formula auto-updated on release)
 
 ### 11.3 CI/CD
 
 **GitHub Actions Workflows**:
 - `ci.yml` - Push/PR: format check, tests, build verification
-- `release.yml` - Tags: GoReleaser publish
+- `release.yml` - Tags: GoReleaser publish + Homebrew tap update
+
+**Required Secrets**:
+- `GITHUB_TOKEN` - Automatic, used for creating GitHub releases
+- `HOMEBREW_TAP_TOKEN` - PAT with `contents: write` on `dgerlanc/homebrew-tap`, used by GoReleaser to push the updated formula
 
 ---
 


### PR DESCRIPTION
Configure GoReleaser to automatically update the dgerlanc/homebrew-tap
formula on each release. This replaces the commented-out homebrew_casks
stub with a proper brews configuration, adds the HOMEBREW_TAP_GITHUB_TOKEN
to the release workflow, and adds Homebrew installation instructions to
the README.

https://claude.ai/code/session_01CkSK1HXtutxHTiq9Tij5ym