### PR TITLE
chore: upgrade Go from 1.25 to 1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.25']
+        go-version: ['1.26']
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dgerlanc/mmi
 
-go 1.25.6
+go 1.26.1
 
 require (
 	github.com/BurntSushi/toml v1.6.0


### PR DESCRIPTION
## Summary
- Update `go.mod` from Go 1.25.6 to Go 1.26.1
- Update CI test matrix from Go 1.25 to Go 1.26

## Test plan
- [x] CI pipeline passes with Go 1.26
- [x] Build job picks up new version from `go.mod`