### PR TITLE
feat: surface config errors in hook output with additional context

### DIFF
--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -68,6 +68,7 @@ type SpecificOutput struct {
 	HookEventName            string `json:"hookEventName"`
 	PermissionDecision       string `json:"permissionDecision"`
 	PermissionDecisionReason string `json:"permissionDecisionReason"`
+	AdditionalContext        string `json:"additionalContext,omitempty"`
 }
 
 // dangerousPattern matches command substitution syntax
@@ -200,6 +201,7 @@ func ProcessWithResult(r io.Reader) Result {
 	logger.Debug("processing command", "command", cmd)
 
 	cfg := config.Get()
+	configErr := config.InitError()
 
 	cmdSegments, err := SplitCommandChain(cmd)
 	if err != nil {
@@ -306,6 +308,11 @@ func ProcessWithResult(r io.Reader) Result {
 		var output string
 		if hasDenyMatch {
 			output = `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"command matches deny list"}}`
+		} else if configErr != nil {
+			output = FormatAskWithContext(
+				"mmi config error: "+configErr.Error(),
+				"WARNING: mmi configuration failed to load. All commands require manual approval until the config is fixed. Run 'mmi validate' to see the error details.",
+			)
 		} else {
 			output = FormatAsk("command not in allow list")
 		}
@@ -398,6 +405,24 @@ func FormatApproval(reason string) string {
 	data, err := json.Marshal(output)
 	if err != nil {
 		logger.Debug("failed to marshal approval output", "error", err)
+		return `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","permissionDecisionReason":"internal error"}}`
+	}
+	return string(data)
+}
+
+// FormatAskWithContext returns the JSON ask output with additional context for Claude.
+func FormatAskWithContext(reason, context string) string {
+	output := Output{
+		HookSpecificOutput: SpecificOutput{
+			HookEventName:            EventPreToolUse,
+			PermissionDecision:       DecisionAsk,
+			PermissionDecisionReason: reason,
+			AdditionalContext:        context,
+		},
+	}
+	data, err := json.Marshal(output)
+	if err != nil {
+		logger.Debug("failed to marshal ask output with context", "error", err)
 		return `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","permissionDecisionReason":"internal error"}}`
 	}
 	return string(data)

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -1607,6 +1607,60 @@ func TestProcessWithResultAuditConfigErrorOnInvalidConfig(t *testing.T) {
 	}
 }
 
+func TestProcessWithResultConfigErrorInOutput(t *testing.T) {
+	config.Reset()
+
+	// Set up a directory with invalid TOML
+	tmpDir, err := os.MkdirTemp("", "mmi-config-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	origConfig := os.Getenv("MMI_CONFIG")
+	os.Setenv("MMI_CONFIG", tmpDir)
+	defer func() {
+		os.Setenv("MMI_CONFIG", origConfig)
+		config.Reset()
+	}()
+
+	invalidConfig := `bad toml {{`
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.toml"), []byte(invalidConfig), 0644); err != nil {
+		t.Fatalf("Failed to write config: %v", err)
+	}
+
+	config.Init()
+
+	// Disable audit logging for this test
+	audit.Init("", true)
+
+	input := `{"session_id":"sess-1","tool_use_id":"tool-1","cwd":"/test","tool_name":"Bash","tool_input":{"command":"ls"}}`
+
+	result := ProcessWithResult(strings.NewReader(input))
+	if result.Approved {
+		t.Error("Command should not be approved when config is invalid")
+	}
+
+	// Parse the output JSON to verify it contains config error info
+	var output Output
+	if err := json.Unmarshal([]byte(result.Output), &output); err != nil {
+		t.Fatalf("Failed to parse output JSON: %v", err)
+	}
+
+	if output.HookSpecificOutput.PermissionDecision != DecisionAsk {
+		t.Errorf("PermissionDecision = %q, want %q", output.HookSpecificOutput.PermissionDecision, DecisionAsk)
+	}
+	if !strings.Contains(output.HookSpecificOutput.PermissionDecisionReason, "mmi config error") {
+		t.Errorf("PermissionDecisionReason = %q, want it to contain 'mmi config error'", output.HookSpecificOutput.PermissionDecisionReason)
+	}
+	if output.HookSpecificOutput.AdditionalContext == "" {
+		t.Error("Expected AdditionalContext to be non-empty when config is invalid")
+	}
+	if !strings.Contains(output.HookSpecificOutput.AdditionalContext, "mmi validate") {
+		t.Errorf("AdditionalContext = %q, want it to contain 'mmi validate'", output.HookSpecificOutput.AdditionalContext)
+	}
+}
+
 func TestCommandSubstitutionRejectedByDefault(t *testing.T) {
 	cleanupConfig := setupTestConfig(t, `
 [[commands.simple]]


### PR DESCRIPTION
## Summary
- Add `AdditionalContext` field to `SpecificOutput` for richer hook responses
- When mmi config fails to load, return an ask decision with a descriptive error message and context directing the user to run `mmi validate`, instead of silently falling back to "command not in allow list"
- Add `FormatAskWithContext()` helper for producing ask output with additional context

## Test plan
- [x] New test `TestProcessWithResultConfigErrorInOutput` validates output contains config error info and `mmi validate` suggestion
- [ ] Manually verify with a broken config that Claude sees the helpful error context