### PR TITLE
fix: switch homebrew from cask to formula

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,7 +63,7 @@ release:
 
     Mother May I? - Claude Code Bash command approval hook
 
-homebrew_casks:
+brews:
   - name: mmi
     repository:
       owner: dgerlanc
@@ -71,5 +71,5 @@ homebrew_casks:
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     homepage: https://github.com/dgerlanc/mmi
     description: "Claude Code Bash command approval hook"
-    binaries:
-      - mmi
+    install: |
+      bin.install "mmi"


### PR DESCRIPTION
## Summary
- Switch GoReleaser config from `homebrew_casks` to `brews` to distribute mmi as a Homebrew formula instead of a cask
- Casks trigger macOS Gatekeeper "not opened" warnings; plain formulas install without code signing issues
- After release, old `Casks/mmi.rb` in homebrew-tap can be deleted

## Test plan
- [ ] Run `goreleaser check` to validate config
- [ ] Cut a release and verify `Formula/mmi.rb` is created in homebrew-tap
- [ ] Install via `brew install dgerlanc/tap/mmi` and confirm no Gatekeeper warning