### PR TITLE
Treat single-quoted strings as literal in dangerous-pattern check

### DIFF
--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -78,10 +78,15 @@ type byteRange struct {
 	start, end int
 }
 
-// findQuotedHeredocRanges parses a command and returns byte ranges of heredoc content
-// where the delimiter is quoted (single or double quotes). Quoted heredocs don't perform
-// shell expansion, so backticks and $() inside them are literal text, not command substitution.
-func findQuotedHeredocRanges(cmd string) []byteRange {
+// findLiteralRanges parses a command and returns byte ranges of regions where shell
+// expansion does not occur, so $() and backticks inside them are literal text. This
+// covers two cases:
+//   - Single-quoted strings ('...'): the shell never expands anything inside.
+//   - Quoted heredocs (<<'EOF' or <<"EOF"): same, by virtue of the quoted delimiter.
+//
+// Double-quoted strings are NOT included: $() and backticks are still expanded inside
+// double quotes.
+func findLiteralRanges(cmd string) []byteRange {
 	parser := syntax.NewParser()
 	prog, err := parser.Parse(strings.NewReader(cmd), "")
 	if err != nil {
@@ -89,39 +94,35 @@ func findQuotedHeredocRanges(cmd string) []byteRange {
 	}
 
 	var ranges []byteRange
+	addRange := func(start, end int) {
+		if start < end && start >= 0 && end <= len(cmd) {
+			ranges = append(ranges, byteRange{start: start, end: end})
+		}
+	}
+
 	syntax.Walk(prog, func(node syntax.Node) bool {
-		redir, ok := node.(*syntax.Redirect)
-		if !ok {
-			return true
-		}
-
-		// Check if this is a heredoc operator (<< or <<-)
-		if redir.Op != syntax.Hdoc && redir.Op != syntax.DashHdoc {
-			return true
-		}
-
-		// Check if the delimiter is quoted
-		if redir.Word == nil || len(redir.Word.Parts) == 0 {
-			return true
-		}
-
-		isQuoted := false
-		for _, part := range redir.Word.Parts {
-			switch part.(type) {
-			case *syntax.SglQuoted, *syntax.DblQuoted:
-				isQuoted = true
+		switch n := node.(type) {
+		case *syntax.SglQuoted:
+			addRange(int(n.Pos().Offset()), int(n.End().Offset()))
+		case *syntax.Redirect:
+			// Heredoc with a quoted delimiter — no expansion inside the body.
+			if n.Op != syntax.Hdoc && n.Op != syntax.DashHdoc {
+				return true
+			}
+			if n.Word == nil || len(n.Word.Parts) == 0 || n.Hdoc == nil {
+				return true
+			}
+			isQuoted := false
+			for _, part := range n.Word.Parts {
+				switch part.(type) {
+				case *syntax.SglQuoted, *syntax.DblQuoted:
+					isQuoted = true
+				}
+			}
+			if isQuoted {
+				addRange(int(n.Hdoc.Pos().Offset()), int(n.Hdoc.End().Offset()))
 			}
 		}
-
-		// If quoted and has heredoc content, record the range
-		if isQuoted && redir.Hdoc != nil {
-			start := int(redir.Hdoc.Pos().Offset())
-			end := int(redir.Hdoc.End().Offset())
-			if start < end && start >= 0 && end <= len(cmd) {
-				ranges = append(ranges, byteRange{start: start, end: end})
-			}
-		}
-
 		return true
 	})
 
@@ -129,9 +130,10 @@ func findQuotedHeredocRanges(cmd string) []byteRange {
 }
 
 // containsDangerousPattern checks if the command contains dangerous patterns ($( or backticks)
-// while excluding content inside quoted heredocs where these characters are literal.
+// while excluding content inside single-quoted strings and quoted heredocs where these
+// characters are literal.
 func containsDangerousPattern(cmd string) bool {
-	excludeRanges := findQuotedHeredocRanges(cmd)
+	excludeRanges := findLiteralRanges(cmd)
 
 	// If no heredocs, do the simple check
 	if len(excludeRanges) == 0 {

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -172,7 +172,7 @@ EOF`,
 		},
 		{
 			name:      "single quotes adjacent to double quotes",
-			cmd:       `echo 'safe `+"`text`"+`'"unsafe `+"`text`"+`"`,
+			cmd:       `echo 'safe ` + "`text`" + `'"unsafe ` + "`text`" + `"`,
 			dangerous: true,
 		},
 	}

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -136,6 +136,45 @@ EOF`,
 	EOF`,
 			dangerous: true,
 		},
+
+		// Single-quoted strings: shell does not expand $() or backticks inside.
+		// BigQuery uses backticks to quote table identifiers, which collides with
+		// the simple substring check unless we recognize the quoting context.
+		{
+			name:      "backticks inside single-quoted string",
+			cmd:       "bq query 'SELECT * FROM `proj.ds.tbl`'",
+			dangerous: false,
+		},
+		{
+			name:      "command substitution inside single-quoted string",
+			cmd:       `echo 'literal $(whoami) here'`,
+			dangerous: false,
+		},
+		{
+			name:      "backticks in double-quoted string still dangerous",
+			cmd:       "echo \"hello `whoami`\"",
+			dangerous: true,
+		},
+		{
+			name:      "$() in double-quoted string still dangerous",
+			cmd:       `echo "hello $(whoami)"`,
+			dangerous: true,
+		},
+		{
+			name:      "dangerous pattern outside single-quoted string",
+			cmd:       "echo $(whoami) 'safe `text`'",
+			dangerous: true,
+		},
+		{
+			name:      "single-quoted string after dangerous pattern",
+			cmd:       "echo `whoami` && echo 'safe'",
+			dangerous: true,
+		},
+		{
+			name:      "single quotes adjacent to double quotes",
+			cmd:       `echo 'safe `+"`text`"+`'"unsafe `+"`text`"+`"`,
+			dangerous: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -148,23 +187,25 @@ EOF`,
 	}
 }
 
-func TestFindQuotedHeredocRanges(t *testing.T) {
+func TestFindLiteralRanges(t *testing.T) {
 	tests := []struct {
 		name       string
 		cmd        string
 		wantRanges int
 	}{
 		{
-			name:       "no heredoc",
+			name:       "no quoting",
 			cmd:        `echo hello`,
 			wantRanges: 0,
 		},
 		{
+			// One range for the 'EOF' delimiter (a single-quoted string in its own
+			// right), one for the heredoc body.
 			name: "single quoted heredoc",
 			cmd: `cat << 'EOF'
 content
 EOF`,
-			wantRanges: 1,
+			wantRanges: 2,
 		},
 		{
 			name: "double quoted heredoc",
@@ -188,7 +229,7 @@ EOF1
 cat << 'EOF2'
 content2
 EOF2`,
-			wantRanges: 2,
+			wantRanges: 4,
 		},
 		{
 			name: "mixed quoted and unquoted heredocs",
@@ -198,15 +239,38 @@ EOF1
 cat << EOF2
 content2
 EOF2`,
+			wantRanges: 2,
+		},
+		{
+			name:       "single-quoted string",
+			cmd:        `echo 'hello world'`,
 			wantRanges: 1,
+		},
+		{
+			name:       "double-quoted string is not literal",
+			cmd:        `echo "hello world"`,
+			wantRanges: 0,
+		},
+		{
+			name:       "multiple single-quoted strings",
+			cmd:        `echo 'one' 'two' 'three'`,
+			wantRanges: 3,
+		},
+		{
+			// 'literal' + 'EOF' delimiter + heredoc body.
+			name: "single-quoted string and quoted heredoc",
+			cmd: `echo 'literal' && cat << 'EOF'
+content
+EOF`,
+			wantRanges: 3,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ranges := findQuotedHeredocRanges(tt.cmd)
+			ranges := findLiteralRanges(tt.cmd)
 			if len(ranges) != tt.wantRanges {
-				t.Errorf("findQuotedHeredocRanges(%q) returned %d ranges, want %d", tt.cmd, len(ranges), tt.wantRanges)
+				t.Errorf("findLiteralRanges(%q) returned %d ranges, want %d", tt.cmd, len(ranges), tt.wantRanges)
 			}
 		})
 	}


### PR DESCRIPTION
The dangerous-pattern check rejected any command containing `$(` or a backtick, even when those characters appeared inside a single-quoted string and were never going to be interpreted by the shell. This broke realistic invocations like

```
bq query 'SELECT * FROM `project.dataset.table` WHERE …'
```

where BigQuery's backtick-quoted identifier is purely literal SQL.

Refactor findQuotedHeredocRanges into findLiteralRanges, walking the AST once to collect both:
  - quoted-heredoc bodies (<<'EOF' and <<"EOF"), and
  - *syntax.SglQuoted nodes (single-quoted strings).

containsDangerousPattern now excludes both kinds of ranges. Double-quoted strings remain in scope because the shell still expands $() and backticks inside them.

Add coverage for single-quoted backticks/`$()`, the inverse double-quoted cases (still dangerous), and mixed contexts where dangerous patterns sit outside the quoted region.